### PR TITLE
すべてのバージョンでflake8テストを行うようにする

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -9,9 +9,9 @@ envlist =
 
 [travis]
 python =
-    3.3: py33
-    3.4: py34
-    3.5: py35
+    3.3: py33, flake8
+    3.4: py34, flake8
+    3.5: py35, flake8
     3.6: py36, flake8
 
 [testenv]

--- a/tox.ini
+++ b/tox.ini
@@ -14,7 +14,7 @@ python =
     3.4: py34, flake8
     3.5: py35, flake8
     3.6: py36, flake8
-    3.7-dev: py37
+    3.7-dev: py37, flake8
 
 [testenv]
 deps=


### PR DESCRIPTION
flake8が失敗したときにcoverallsテストが出て見にくいので