### PR TITLE
Base64とbase32の追加

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -2,6 +2,7 @@
 include =
     des.py
     dbi.py
+    base64_32.py
 
 exclude_lines =
     pragma: no cover

--- a/base64_32.py
+++ b/base64_32.py
@@ -1,0 +1,29 @@
+import base64
+
+
+def base64encode(s):
+    if len(s) != 8:
+        return None
+    return base64.urlsafe_b64encode(s).decode('utf-8')[:-1]
+
+
+def base32encode(s):
+    if len(s) != 8:
+        return None
+    return base64.b32encode(s).decode('utf-8')[:-3].lower()
+
+
+def base64decode(s):
+    if len(s) == 11:
+        s += '='
+    else:
+        return None
+    return base64.urlsafe_b64decode(s)
+
+
+def base32decode(s):
+    if len(s) == 13:
+        s += '==='
+    else:
+        return None
+    return base64.b32decode(s.upper(), casefold=True, map01='l')

--- a/tests/test_base64_32.py
+++ b/tests/test_base64_32.py
@@ -1,0 +1,34 @@
+import unittest
+import base64_32
+
+
+class test_des(unittest.TestCase):
+    def test_base64encode(self):
+        self.assertEqual(base64_32.base64encode(b'!\xec\xdb\xc1\xa8Z\xe0\xe2'), 'Iezbwaha4OI')
+        self.assertEqual(base64_32.base64encode(b'11451442'), 'MTE0NTE0NDI')
+        self.assertEqual(base64_32.base64encode(b'\xfe\xfe\xfe\xfe\xff\xff\xff\xff'), '_v7-_v____8')
+        self.assertIsNone(base64_32.base64encode(b'114514'))
+
+
+    def test_base32encode(self):
+        self.assertEqual(base64_32.base32encode(b'!\xec\xdb\xc1\xa8Z\xe0\xe2'), 'ehwnxqnillqoe')
+        self.assertEqual(base64_32.base32encode(b'11451442'), 'geytinjrgq2de')
+        self.assertEqual(base64_32.base32encode(b'\xfe\xfe\xfe\xfe\xff\xff\xff\xff'), '737p57x777776')
+        self.assertIsNone(base64_32.base32encode(b'114514'))
+
+    def test_base64decode(self):
+        self.assertEqual(base64_32.base64decode('Iezbwaha4OI'), b'!\xec\xdb\xc1\xa8Z\xe0\xe2')
+        self.assertEqual(base64_32.base64decode('MTE0NTE0NDI'), b'11451442')
+        self.assertEqual(base64_32.base64decode('_v7-_v____8'), b'\xfe\xfe\xfe\xfe\xff\xff\xff\xff')
+        self.assertIsNone(base64_32.base64decode('12345678'))
+
+    def test_base32decode(self):
+        self.assertEqual(base64_32.base32decode('ehwnxqnillqoe'), b'!\xec\xdb\xc1\xa8Z\xe0\xe2')
+        self.assertEqual(base64_32.base32decode('ehwnxqni11q0e'), b'!\xec\xdb\xc1\xa8Z\xe0\xe2')
+        self.assertEqual(base64_32.base32decode('geytinjrgq2de'), b'11451442')
+        self.assertEqual(base64_32.base32decode('737p57x777776'), b'\xfe\xfe\xfe\xfe\xff\xff\xff\xff')
+        self.assertIsNone(base64_32.base32decode('12345678'))
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
標準の関数とは異なり以下の点を変更している

- 末尾の=を除去
- base32では小文字に変換

